### PR TITLE
Introduce a first test using the new assertion DSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+all: test
+
+clean:
+	rm -rf target
+
 compile:
 	mkdir -p target
 	bash src/aggregate.sh > target/sbtest.sh
+
+test: compile
+	chmod +x target/sbtest.sh
+	target/sbtest.sh

--- a/src/asserts.sh
+++ b/src/asserts.sh
@@ -5,3 +5,23 @@ assert_int() {
 
     test ${actual} -eq ${expected} || fail "Expected <$expected>\nGot:      <$actual>"
 }
+
+assert() {
+    local actual=$1
+    local directive=$2
+    local expected=$3
+
+    _assert_${directive} ${actual} ${expected}
+}
+
+_assert_equals() {
+    test ${1} -eq ${2} || fail "Expected <$2>\nGot:      <$1>"
+}
+
+_assert_succeeded() {
+    test ${1} -eq 0 || fail "Expected success exit code\nGot:      <$1>"
+}
+
+_assert_failed() {
+    test ${1} -ne 0 || fail "Expected failure exit code\nGot:      <$1>"
+}

--- a/src/test-running.sh
+++ b/src/test-running.sh
@@ -62,7 +62,7 @@ for test in ${tests}; do
     echo "ok"
 
     _cleanup
-    popd
+    popd >/dev/null
 done
 
 trap - INT TERM EXIT

--- a/test/test_assert.sh
+++ b/test/test_assert.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+test_asset_equals_with_integer_passing() {
+    (assert 1 equals 1)
+
+    assert ${?} succeeded
+}
+
+test_asset_equals_with_integer_failing() {
+    (assert 1 equals 0)
+
+    assert ${?} failed
+}


### PR DESCRIPTION
The assertion DSL is expected to look like

assert $actual equals $expected

and many directives will be defined such as

assert $? succeeded
assert $? failed

For exit code assertions