### PR TITLE
Provide better failure output

### DIFF
--- a/src/asserts.sh
+++ b/src/asserts.sh
@@ -8,13 +8,13 @@ assert() {
 }
 
 _assert_equals() {
-    test "${1}" == "${2}" || fail "Expected <$2>\nGot:      <$1>"
+    test "${1}" == "${2}" || assertion_failed "Expected: <$2>\nGot:      <$1>"
 }
 
 _assert_succeeded() {
-    test ${1} -eq 0 || fail "Expected success exit code\nGot:      <$1>"
+    test ${1} -eq 0 || assertion_failed "Expected success exit code\nGot: <$1>"
 }
 
 _assert_failed() {
-    test ${1} -ne 0 || fail "Expected failure exit code\nGot:      <$1>"
+    test ${1} -ne 0 || assertion_failed "Expected failure exit code\nGot: <$1>"
 }

--- a/test-fixtures/failing-test/src/fail.sh
+++ b/test-fixtures/failing-test/src/fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 1

--- a/test-fixtures/failing-test/test/test_failing.sh
+++ b/test-fixtures/failing-test/test/test_failing.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+test_that_fails() {
+    (bash fail.sh)
+    assert ${?} succeeded
+}

--- a/test/test_assert.sh
+++ b/test/test_assert.sh
@@ -7,9 +7,19 @@ test_assert_equals_with_integers() {
 }
 
 test_assert_equals_with_integer_failing() {
-    (assert 1 equals 0)
+    assert 1 equals 0 > assertion_output
+    result=${?}
+    rm .assertion_error # The test runner would think the test failed
 
-    assert ${?} failed
+    assertion_error=$(cat assertion_output)
+
+    expected_error=$(cat <<-EXP
+Expected: <0>
+Got:      <1>
+EXP
+)
+    assert ${result} failed
+    assert "${assertion_error}" equals "${expected_error}"
 }
 
 test_assert_equals_with_strings_passing() {
@@ -19,9 +29,19 @@ test_assert_equals_with_strings_passing() {
 }
 
 test_assert_equals_with_strings_failing() {
-    (assert "no" equals "yes")
+    assert "no" equals "yes" > assertion_output
+    result=${?}
+    rm .assertion_error # The test runner would think the test failed
 
-    assert ${?} failed
+    assertion_error=$(cat assertion_output)
+
+    expected_error=$(cat <<-EXP
+Expected: <yes>
+Got:      <no>
+EXP
+)
+    assert ${result} failed
+    assert "${assertion_error}" equals "${expected_error}"
 }
 
 test_assert_multiworks_string_works() {

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -78,3 +78,35 @@ EXP
 )
     assert "${actual}" equals "${expected}"
 }
+
+test_output_is_fine_when_a_test_fails() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/failing-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+failing.that_fails...FAILED
+
+=========================
+FAIL: failing.that_fails
+-------------------------
+Expected success exit code
+Got: <1>
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 error) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}


### PR DESCRIPTION
To achieve this, the assertion system not killing the process anymore
(exit 1) instead it juste returns a non-zero result and touches a file
saying there was an assertion error, this lets the runner complete its
job and then show the errors