### PR TITLE
Add support to run only one test or suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ clean:
 compile:
 	mkdir -p target
 	bash src/aggregate.sh > target/sbtest.sh
+	chmod +x target/sbtest.sh
 
 test: compile
-	chmod +x target/sbtest.sh
 	target/sbtest.sh
+
+.DEFAULT: compile
+	target/sbtest.sh $@

--- a/README.md
+++ b/README.md
@@ -50,3 +50,16 @@ test
         assert ${?} succeeded
     }
     
+
+Contributing
+============
+
+Feel free to add stuff in here :)
+
+Running the tests:
+
+    make test
+    
+you can run only one suite/test with
+
+    make suite.test

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -3,16 +3,25 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
 
     sources_root="src"
     test_sources_root="test"
+    test_suites_filter="test_*"
+    test_filter="^test_"
 
-    while [[ $# -gt 1 ]]; do
+    while [[ $# -gt 0 ]]; do
         key="$1"
 
-        case $key in
+        case ${key} in
             --src)
             sources_root="$2"; shift
             ;;
             --tests)
             test_sources_root="$2"; shift
+            ;;
+            *)
+            if [[ ${key} == *"."* ]]; then
+                test_filter="^test_${key##*.}$"
+                key=${key%.*}
+            fi
+            test_suites_filter="test_${key}.sh"
             ;;
         esac
         shift
@@ -29,8 +38,8 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
     registry="$(mktemp -d "/tmp/workspace.registry.XXXXXXXX")"
     test_count=0
 
-    for f in $(find ${test_sources_root} -name "test_*"); do
-        TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${registry} || fail "${f} failed."
+    for f in $(find ${test_sources_root} -name "${test_suites_filter}"); do
+        TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${test_filter} ${registry} || fail "${f} failed."
 
         new_tests=$(cat ${registry}/test_count)
         test_count=$((${test_count} + ${new_tests}))

--- a/src/test-runner.sh
+++ b/src/test-runner.sh
@@ -1,12 +1,13 @@
 
 SOURCE_ROOT=$1
 TEST_FILE=$2
-REGISTRY=$3
+TESTS_FILTER=$3
+REGISTRY=$4
 
 source ${TEST_FILE} || fail "Unable to read ${TEST_FILE}."
 
 all_functions=$(typeset -F | sed "s/declare -f //")
-tests=$(echo "${all_functions}" | grep "^test_" || true)
+tests=$(echo "${all_functions}" | grep ${TESTS_FILTER} || true)
 setup=$(echo "${all_functions}" | grep "^setup$" || true)
 teardown=$(echo "${all_functions}" | grep "^teardown" || true)
 

--- a/test/test_runner_args.sh
+++ b/test/test_runner_args.sh
@@ -31,8 +31,8 @@ test_can_specify_alternative_relative_paths_src() {
 
     unset RUN_SINGLE_TEST
     actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh \
-                --src ./unconventional-test/not-src \
-                --tests ./unconventional-test/not-test)
+                --tests ./unconventional-test/not-test \
+                --src ./unconventional-test/not-src)
     assert ${?} succeeded
 
     expected=$(cat <<-EXP
@@ -65,6 +65,55 @@ Running Simple Bash Tests
 -------------------------
 
 stuff.stuff...OK
+
+-------------------------
+Ran 1 test
+
+>>> SUCCESS <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_can_run_only_one_test_suite_by_name() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/multi-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh one-two)
+    assert ${?} succeeded
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+one-two.1...OK
+one-two.2...OK
+
+-------------------------
+Ran 2 tests
+
+>>> SUCCESS <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_can_run_only_one_test_by_name() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/multi-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh one-two.1)
+    assert ${?} succeeded
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+one-two.1...OK
 
 -------------------------
 Ran 1 test


### PR DESCRIPTION
The parameter to sbtest.sh can now be a suite name or test name.

By name we mean without the prefix test_ and the suffix .sh

No parameters will run all the tests