### PR TITLE
Capture the tests' stderr output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,4 @@ compile:
 	chmod +x target/sbtest.sh
 
 test: compile
-	target/sbtest.sh
-
-.DEFAULT: compile
-	target/sbtest.sh $@
+	target/sbtest.sh ${TEST}

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Running the tests:
     
 you can run only one suite/test with
 
-    make suite.test
+    make test TEST=suite.test

--- a/src/test-runner.sh
+++ b/src/test-runner.sh
@@ -63,7 +63,7 @@ for test in ${tests}; do
 
     failed=0
 
-    ${test} > ${workspace}/test_output || true
+    ${test} >${workspace}/test_output 2>${workspace}/test_output_err || true
 
     if [ ! -f ${workspace}/.assertion_error ]; then
         echo "OK"
@@ -74,8 +74,10 @@ for test in ${tests}; do
 
 =========================
 FAIL: ${test_name}
--------------------------
+-------- STDOUT ---------
 $(cat ${workspace}/test_output)
+-------- STDERR ---------
+$(cat ${workspace}/test_output_err)
 -------------------------
 FAILURE
 

--- a/test-fixtures/failing-test/src/fail-with-stderr.sh
+++ b/test-fixtures/failing-test/src/fail-with-stderr.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "This is stuff" 1>&2
+echo "from stderr" 1>&2
+
+exit 1

--- a/test-fixtures/failing-test/test/test_failing.sh
+++ b/test-fixtures/failing-test/test/test_failing.sh
@@ -4,3 +4,8 @@ test_that_fails() {
     (bash fail.sh)
     assert ${?} succeeded
 }
+
+test_that_fails_with_stderr() {
+    (bash fail-with-stderr.sh)
+    assert ${?} succeeded
+}

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -84,7 +84,7 @@ test_output_is_fine_when_a_test_fails() {
     cp -aR ${TEST_ROOT_DIR}/../test-fixtures/failing-test/* .
 
     unset RUN_SINGLE_TEST
-    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh)
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh failing.that_fails)
     assert ${?} failed
 
     expected=$(cat <<-EXP
@@ -96,9 +96,46 @@ failing.that_fails...FAILED
 
 =========================
 FAIL: failing.that_fails
--------------------------
+-------- STDOUT ---------
 Expected success exit code
 Got: <1>
+-------- STDERR ---------
+
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 error) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_output_also_show_stderr_when_a_test_fails() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/failing-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh failing.that_fails_with_stderr)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+failing.that_fails_with_stderr...FAILED
+
+=========================
+FAIL: failing.that_fails_with_stderr
+-------- STDOUT ---------
+Expected success exit code
+Got: <1>
+-------- STDERR ---------
+This is stuff
+from stderr
 -------------------------
 
 -------------------------


### PR DESCRIPTION
This will show the stderr in the failure report only and leave a
clean test run.

Also, the makefile with .DEFAULT was not compiling, so let's
use a parametrable test target