### PR TITLE
Support successive mockings for the same command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ clean.sh
 test
 
     test_clean_works() {
-        mock rm --with-args "somewhere/some-file" --and exitcode 0
+        mock rm --and exit-code 0
     
         bash ./clean.sh some-file
     

--- a/examples/2-mocking/test/test_clean.sh
+++ b/examples/2-mocking/test/test_clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 test_clean_works() {
-    mock rm --with-args "somewhere/some-file" --and exitcode 0
+    mock rm --and exit-code 0
 
     bash ./clean.sh some-file
 
@@ -9,7 +9,7 @@ test_clean_works() {
 }
 
 test_clean_works_fails() {
-    mock rm --with-args "somewhere/non-existing-file" --and exitcode 1
+    mock rm --and exit-code 1
 
     bash ./clean.sh non-existing-file
 

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -38,7 +38,7 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
     registry="$(mktemp -d "/tmp/workspace.registry.XXXXXXXX")"
     test_count=0
 
-    for f in $(find ${test_sources_root} -name "${test_suites_filter}"); do
+    for f in $(find ${test_sources_root} -name "${test_suites_filter}" | sort); do
         TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${test_filter} ${registry} || fail "${f} failed."
 
         new_tests=$(cat ${registry}/test_count)

--- a/test/test_mocking.sh
+++ b/test/test_mocking.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+test_mocking_a_command_with_a_success_exit_code() {
+    mock some-command --and exit-code 0
+
+    some-command
+    assert ${?} succeeded
+}
+
+test_mocking_a_command_with_a_failure_exit_code() {
+    mock some-command --and exit-code 1
+
+    some-command
+    assert ${?} failed
+}
+
+test_mocking_a_command_to_return_a_value_and_exit_success() {
+    mock some-command --and echo "hello" --and exit-code 0
+
+    result=$(some-command)
+    assert ${?} succeeded
+
+    assert "${result}" equals "hello"
+}
+
+test_mocking_a_command_to_return_a_value_and_exit_failure() {
+    mock some-command --and echo "hello" --and exit-code 1
+
+    result=$(some-command)
+    assert ${?} failed
+
+    assert "${result}" equals "hello"
+}
+
+test_mocking_several_times_the_same_command() {
+    mock some-command --and exit-code 0
+    mock some-command --and exit-code 1
+    mock some-command --and exit-code 0
+
+    some-command
+    assert ${?} succeeded
+
+    some-command
+    assert ${?} failed
+
+    some-command
+    assert ${?} succeeded
+}
+
+test_no_mock_count_mocks_all_the_calls() {
+    mock some-command --and exit-code 0
+
+    some-command
+    assert ${?} succeeded
+
+    some-command
+    assert ${?} succeeded
+}
+
+test_mocking_a_second_time_assume_the_first_was_a_one_time_and_mocks_all_other_calls() {
+    mock some-command --and exit-code 1
+    mock some-command --and exit-code 0
+
+    some-command
+    assert ${?} failed
+
+    some-command
+    assert ${?} succeeded
+
+    some-command
+    assert ${?} succeeded
+}


### PR DESCRIPTION
By introducing a "workspace" for the mock we can have several
"workspace" related values in files that describe the mock, such
as the successive invocations.

So now the code that is in the fake executable becomes standard
and react to the content of the workspace.

The support for --with-args have been completely removed and
will be reintroduced in an upcoming change with tests

The file sort is to ensure the tests runs the same on any machine,
it would seem that "find" does not guarantee an order