### PR TITLE
Show errors in test

### DIFF
--- a/src/cli.sh
+++ b/src/cli.sh
@@ -60,7 +60,7 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
         echo ""
         exit 0
     else
-        echo ">>> FAILURE ("$(_format_count ${failure_count} "error")") <<<"
+        echo ">>> FAILURE ("$(_format_count ${failure_count} "problem")") <<<"
         echo ""
         exit 1
     fi

--- a/test-fixtures/erroring-test/src/code.sh
+++ b/test-fixtures/erroring-test/src/code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Sample source code

--- a/test-fixtures/erroring-test/test/test_erroring.sh
+++ b/test-fixtures/erroring-test/test/test_erroring.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+test_non_existing_command() {
+    echo "stuff on stdout"
+    echo "stuff on stderr" 1>&2
+    return 96
+}

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -106,7 +106,7 @@ Got: <1>
 -------------------------
 Ran 1 test
 
->>> FAILURE (1 error) <<<
+>>> FAILURE (1 problem) <<<
 
 EXP
 )
@@ -141,7 +141,41 @@ from stderr
 -------------------------
 Ran 1 test
 
->>> FAILURE (1 error) <<<
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_with_an_error_while_running_the_test_should_show_it_is_in_error() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/erroring-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh erroring.non_existing_command)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+erroring.non_existing_command...ERROR
+
+=========================
+ERROR: erroring.non_existing_command
+-------- STDOUT ---------
+stuff on stdout
+-------- STDERR ---------
+stuff on stderr
+EXIT CODE : 96
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 problem) <<<
 
 EXP
 )


### PR DESCRIPTION
Before this, any error occuring in a test would pass a a
success because it was not an assertion error.

With this, there is a distinction between a failure (assertion
failed) and an error where the test could not complete due to
an operation exiting with a non-zero code.