### PR TITLE
Support --once in mocking

### DIFF
--- a/src/test-runner.sh
+++ b/src/test-runner.sh
@@ -81,6 +81,8 @@ for test in ${tests}; do
 
     ${test} >${workspace}/test_output 2>${workspace}/test_output_err || error_code=${?}
 
+    _verify_mocks >>${workspace}/test_output 2>>${workspace}/test_output_err || true
+
     if [ -f ${workspace}/.assertion_error ]; then
         echo "FAILED"
         failures=$((${failures} + 1))
@@ -94,6 +96,7 @@ for test in ${tests}; do
         echo "OK"
     fi
     test_count=$((${test_count} + 1))
+    error_code=""
 
     _cleanup
     popd >/dev/null

--- a/test-fixtures/call_counts_tests/src/code.sh
+++ b/test-fixtures/call_counts_tests/src/code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Sample source code

--- a/test-fixtures/call_counts_tests/test/test_call_counts.sh
+++ b/test-fixtures/call_counts_tests/test/test_call_counts.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+test_not_called_once() {
+    mock some-command --once
+
+    echo "Test stdout"
+    echo "Test stderr" 1>&2
+}
+
+test_called_twice() {
+    mock some-command --once
+
+    some-command
+    assert ${?} succeeded
+    some-command
+    assert ${?} failed
+}

--- a/test-fixtures/failing-test/test/test_failing.sh
+++ b/test-fixtures/failing-test/test/test_failing.sh
@@ -9,3 +9,7 @@ test_that_fails_with_stderr() {
     (bash fail-with-stderr.sh)
     assert ${?} succeeded
 }
+
+test_that_works() {
+    :
+}

--- a/test/test_mocking_call_counts.sh
+++ b/test/test_mocking_call_counts.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+test_specifying_once_fails_when_not_called() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/call_counts_tests/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh call_counts.not_called_once)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+call_counts.not_called_once...FAILED
+
+=========================
+FAIL: call_counts.not_called_once
+-------- STDOUT ---------
+Test stdout
+Command 'some-command' was expected to be called 1 time
+Called : 0 times
+-------- STDERR ---------
+Test stderr
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_specifying_once_fails_when_called_twice() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/call_counts_tests/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh call_counts.called_twice)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+call_counts.called_twice...FAILED
+
+=========================
+FAIL: call_counts.called_twice
+-------- STDOUT ---------
+Command 'some-command' was expected to be called 1 time
+Called : 2 times
+-------- STDERR ---------
+
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -181,3 +181,49 @@ EXP
 )
     assert "${actual}" equals "${expected}"
 }
+
+test_a_failure_doesnt_impact_other_tests() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/failing-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh failing)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+failing.that_fails...FAILED
+failing.that_fails_with_stderr...FAILED
+failing.that_works...OK
+
+=========================
+FAIL: failing.that_fails
+-------- STDOUT ---------
+Expected success exit code
+Got: <1>
+-------- STDERR ---------
+
+-------------------------
+
+=========================
+FAIL: failing.that_fails_with_stderr
+-------- STDOUT ---------
+Expected success exit code
+Got: <1>
+-------- STDERR ---------
+This is stuff
+from stderr
+-------------------------
+
+-------------------------
+Ran 3 tests
+
+>>> FAILURE (2 problems) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}


### PR DESCRIPTION
This ensures the mock is called once, not 0 not more than 1

Every call to the mock beyond 1 will exit with an error