### PR TITLE
Read failure_count after each test suite

### DIFF
--- a/src/cli.sh
+++ b/src/cli.sh
@@ -37,12 +37,15 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
 
     registry="$(mktemp -d "/tmp/workspace.registry.XXXXXXXX")"
     test_count=0
+    failure_count=0
 
     for f in $(find ${test_sources_root} -name "${test_suites_filter}" | sort); do
         TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${test_filter} ${registry} || fail "${f} failed."
 
         new_tests=$(cat ${registry}/test_count)
         test_count=$((${test_count} + ${new_tests}))
+        new_failures=$(cat ${registry}/failures_count)
+        failure_count=$((${failure_count} + ${new_failures}))
     done
 
     if [ -f ${registry}/failures_output ]; then
@@ -54,7 +57,6 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
     echo "Ran "$(_format_count ${test_count} "test")
     echo ""
 
-    failure_count=$(cat ${registry}/failures_count)
     if [ ${failure_count} -eq 0 ]; then
         echo ">>> SUCCESS <<<"
         echo ""

--- a/test-fixtures/multi-suite/src/code.sh
+++ b/test-fixtures/multi-suite/src/code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Sample source code

--- a/test-fixtures/multi-suite/test/test_first.sh
+++ b/test-fixtures/multi-suite/test/test_first.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+test_failing() {
+    assert 1 equals 2
+}

--- a/test-fixtures/multi-suite/test/test_second.sh
+++ b/test-fixtures/multi-suite/test/test_second.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+test_succeeding() {
+    assert 1 equals 1
+}

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -181,3 +181,38 @@ EXP
 )
     assert "${actual}" equals "${expected}"
 }
+
+test_a_failure_is_correctly_reported_after_even_after_another_suite_succeeds() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/multi-suite/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+first.failing...FAILED
+second.succeeding...OK
+
+=========================
+FAIL: first.failing
+-------- STDOUT ---------
+Expected: <2>
+Got:      <1>
+-------- STDERR ---------
+
+-------------------------
+
+-------------------------
+Ran 2 tests
+
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}


### PR DESCRIPTION
If we don't only the result of the last test suite matters in the determining
if the run was a success

Fixes #18