### PR TITLE
Support --once in mocking (Reapplying)

### DIFF
--- a/src/mocking.sh
+++ b/src/mocking.sh
@@ -35,6 +35,7 @@ mock() {
     local actions_params=()
     local action_count=0
     local has_args_validation=false
+    local expected_calls=-1 #any
 
     while [[ $# -gt 0 ]]; do
         local key="$1"
@@ -57,6 +58,9 @@ mock() {
                 return 1
             fi
             ;;
+            --once)
+            expected_calls=1
+            ;;
         esac
         shift
     done
@@ -76,7 +80,10 @@ mock() {
     fi
 
     echo ${invocation_count} > ${mock_workspace}/invocation_count
-    invocation_file="${mock_workspace}/invocation_${invocation_count}"
+    invocation_file="${mock_workspace}/invocation_${invocation_count}_code"
+
+    echo 0 > "${mock_workspace}/invocation_${invocation_count}_calls"
+    echo ${expected_calls} > "${mock_workspace}/invocation_${invocation_count}_expected_calls"
 
     echo "#!/bin/bash" > ${invocation_file}
 
@@ -100,6 +107,30 @@ if [ \${invocation_index} -lt \$(cat \${workspace}/invocation_count) ]; then
     echo \$((invocation_index + 1)) > \${workspace}/invocation_index
 fi
 
-\${workspace}/invocation_\${invocation_index} \${args}
+invocation_calls=\$(cat \${workspace}/invocation_\${invocation_index}_calls)
+echo \$((invocation_calls + 1)) > \${workspace}/invocation_\${invocation_index}_calls
+
+expected_calls=\$(cat \${workspace}/invocation_\${invocation_index}_expected_calls)
+if [ \${expected_calls} -ge 0 ] && [ \$((invocation_calls + 1)) -gt \${expected_calls} ]; then
+    exit 1
+fi
+
+\${workspace}/invocation_\${invocation_index}_code \${args}
 EOF
+}
+
+_verify_mocks() {
+    for mock in $(find ${mocks} -type d -maxdepth 1 -name "_*.workspace" 2>/dev/null || true); do
+        command=$(echo ${mock} | sed 's/.*\/_//' | sed 's/.workspace//')
+
+        for invocation in $(find ${mock} -maxdepth 1 -name "invocation_*_code" 2>/dev/null || true); do
+            invocation_id=$(echo ${invocation} | sed 's/.*\/invocation_//' | sed 's/_code//')
+            call_count=$(cat ${mock}/invocation_${invocation_id}_calls)
+            expected_calls=$(cat ${mock}/invocation_${invocation_id}_expected_calls)
+
+            if [ ${expected_calls} -ge 0 ] && [ ${call_count} -ne ${expected_calls} ]; then
+                assertion_failed "Command '${command}' was expected to be called $(_format_count ${expected_calls} "time")\nCalled : $(_format_count ${call_count} "time")"
+            fi
+        done
+    done
 }

--- a/src/test-runner.sh
+++ b/src/test-runner.sh
@@ -81,6 +81,8 @@ for test in ${tests}; do
 
     ${test} >${workspace}/test_output 2>${workspace}/test_output_err || error_code=${?}
 
+    _verify_mocks >>${workspace}/test_output 2>>${workspace}/test_output_err || true
+
     if [ -f ${workspace}/.assertion_error ]; then
         echo "FAILED"
         failures=$((${failures} + 1))
@@ -94,6 +96,7 @@ for test in ${tests}; do
         echo "OK"
     fi
     test_count=$((${test_count} + 1))
+    error_code=""
 
     _cleanup
     popd >/dev/null

--- a/test-fixtures/call_counts_tests/src/code.sh
+++ b/test-fixtures/call_counts_tests/src/code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Sample source code

--- a/test-fixtures/call_counts_tests/test/test_call_counts.sh
+++ b/test-fixtures/call_counts_tests/test/test_call_counts.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+test_not_called_once() {
+    mock some-command --once
+
+    echo "Test stdout"
+    echo "Test stderr" 1>&2
+}
+
+test_called_twice() {
+    mock some-command --once
+
+    some-command
+    assert ${?} succeeded
+    some-command
+    assert ${?} failed
+}

--- a/test-fixtures/failing-test/test/test_failing.sh
+++ b/test-fixtures/failing-test/test/test_failing.sh
@@ -9,3 +9,7 @@ test_that_fails_with_stderr() {
     (bash fail-with-stderr.sh)
     assert ${?} succeeded
 }
+
+test_that_works() {
+    :
+}

--- a/test/test_mocking_call_counts.sh
+++ b/test/test_mocking_call_counts.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+test_specifying_once_fails_when_not_called() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/call_counts_tests/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh call_counts.not_called_once)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+call_counts.not_called_once...FAILED
+
+=========================
+FAIL: call_counts.not_called_once
+-------- STDOUT ---------
+Test stdout
+Command 'some-command' was expected to be called 1 time
+Called : 0 times
+-------- STDERR ---------
+Test stderr
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
+test_specifying_once_fails_when_called_twice() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/call_counts_tests/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh call_counts.called_twice)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+call_counts.called_twice...FAILED
+
+=========================
+FAIL: call_counts.called_twice
+-------- STDOUT ---------
+Command 'some-command' was expected to be called 1 time
+Called : 2 times
+-------- STDERR ---------
+
+-------------------------
+
+-------------------------
+Ran 1 test
+
+>>> FAILURE (1 problem) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}

--- a/test/test_runner_output.sh
+++ b/test/test_runner_output.sh
@@ -182,6 +182,52 @@ EXP
     assert "${actual}" equals "${expected}"
 }
 
+test_a_failure_doesnt_impact_other_tests() {
+
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/failing-test/* .
+
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh failing)
+    assert ${?} failed
+
+    expected=$(cat <<-EXP
+
+Running Simple Bash Tests
+-------------------------
+
+failing.that_fails...FAILED
+failing.that_fails_with_stderr...FAILED
+failing.that_works...OK
+
+=========================
+FAIL: failing.that_fails
+-------- STDOUT ---------
+Expected success exit code
+Got: <1>
+-------- STDERR ---------
+
+-------------------------
+
+=========================
+FAIL: failing.that_fails_with_stderr
+-------- STDOUT ---------
+Expected success exit code
+Got: <1>
+-------- STDERR ---------
+This is stuff
+from stderr
+-------------------------
+
+-------------------------
+Ran 3 tests
+
+>>> FAILURE (2 problems) <<<
+
+EXP
+)
+    assert "${actual}" equals "${expected}"
+}
+
 test_a_failure_is_correctly_reported_after_even_after_another_suite_succeeds() {
 
     cp -aR ${TEST_ROOT_DIR}/../test-fixtures/multi-suite/* .


### PR DESCRIPTION
This ensures the mock is called once, not 0 not more than 1

Every call to the mock beyond 1 will exit with an error