### PR TITLE
Add cat as a mock option

### DIFF
--- a/src/mocking.sh
+++ b/src/mocking.sh
@@ -1,3 +1,10 @@
+action-cat() {
+    path="$@"
+    cat <<EOF
+cat "${path}"
+EOF
+}
+
 action-echo() {
     text="$@"
     cat <<EOF

--- a/test/data-fixtures/letter.txt
+++ b/test/data-fixtures/letter.txt
@@ -1,0 +1,1 @@
+Hello world.

--- a/test/test_mocking_multi_invocations.sh
+++ b/test/test_mocking_multi_invocations.sh
@@ -32,6 +32,41 @@ test_mocking_a_command_to_return_a_value_and_exit_failure() {
     assert "${result}" equals "hello"
 }
 
+test_mocking_a_command_to_return_content_from_missing_file() {
+    mock some-command --and cat /missing/file
+    result=$(some-command)
+    assert ${?} failed
+}
+
+test_mocking_a_command_to_return_content_from_stdin() {
+    mock some-command --and cat -
+    result=$(echo "yes" | some-command)
+    assert ${?} succeeded
+
+    assert "${result}" equals "yes"
+}
+
+test_mocking_a_command_to_return_content_from_file() {
+    temp_file=$(mktemp ${TMPDIR:-"/tmp/"}/sbtest.XXXXXXXX)
+    echo "yes yes" > ${temp_file}
+
+    mock some-command --and cat ${temp_file}
+    result=$(some-command)
+    assert ${?} succeeded
+
+    assert "${result}" equals "yes yes"
+    rm -f ${temp_file}
+}
+
+test_mocking_a_command_to_return_content_from_file_in_test_root() {
+
+    mock some-command --and cat $TEST_ROOT_DIR/data-fixtures/letter.txt
+    result=$(some-command)
+    assert ${?} succeeded
+
+    assert "${result}" equals "Hello world."
+}
+
 test_mocking_several_times_the_same_command() {
     mock some-command --and exit-code 0
     mock some-command --and exit-code 1


### PR DESCRIPTION
Currently, mocking executions is limited to echo and exit codes. This
forces test fixtures through test code via cat and echo and sometimes
mangles newlines.

This commit allows the use of cat to point to a file on the filesystem.
This is epecially useful when using $TEST_ROOT_DIR to point to test
fixtures.