### PR TITLE
Allow echo and cat to stderr

### DIFF
--- a/src/mocking.sh
+++ b/src/mocking.sh
@@ -5,10 +5,24 @@ cat "${path}"
 EOF
 }
 
+action-cat-stderr() {
+    path="$@"
+    cat <<EOF
+cat "${path}" > /dev/stderr
+EOF
+}
+
 action-echo() {
     text="$@"
     cat <<EOF
 echo "${text}"
+EOF
+}
+
+action-echo-stderr() {
+    text="$@"
+    cat <<EOF
+echo "${text}" > /dev/stderr
 EOF
 }
 


### PR DESCRIPTION
Currently, outputting to stderr requires a custom mock action.

This commit fixes that common use case by including it in the framework.