### PR TITLE
Always verify mock arguments

### DIFF
--- a/src/aggregate.sh
+++ b/src/aggregate.sh
@@ -3,9 +3,14 @@ set -eu
 
 src=$(dirname $0)
 
-cat ${src}/header.sh
-cat ${src}/utils.sh
-cat ${src}/asserts.sh
-cat ${src}/mocking.sh
-cat ${src}/cli.sh
-cat ${src}/test-runner.sh
+include() {
+    cat $1
+    printf '\n'
+}
+
+include ${src}/header.sh
+include ${src}/utils.sh
+include ${src}/asserts.sh
+include ${src}/mocking.sh
+include ${src}/cli.sh
+include ${src}/test-runner.sh

--- a/src/asserts.sh
+++ b/src/asserts.sh
@@ -18,3 +18,7 @@ _assert_succeeded() {
 _assert_failed() {
     test ${1} -ne 0 || assertion_failed "Expected failure exit code\nGot: <$1>"
 }
+
+_assert_contains() {
+    echo "$1" | grep -q "$2" || assertion_failed "Expected:         <$1>\nTo match pattern: <$2>"
+}

--- a/src/mocking.sh
+++ b/src/mocking.sh
@@ -39,13 +39,12 @@ validate-args() {
 args="\$@"
 
 if [ "\${args}" != "${expected}" ]; then
-
-    cat <<OUT
+    cat > \$0_error <<OUT
 Unexpected invocation for command 'some-command':
 Got :      <"\${args}">
 Expected : <"${expected}">
 OUT
-    exit 1
+    exit 1 # Kept for historical reasons. Proper usage would be mock xyz --with-args "arg1 arg2" --and exit-code 1.
 fi
 EOF
 }
@@ -158,6 +157,10 @@ _verify_mocks() {
             if [ ${expected_calls} -ge 0 ] && [ ${call_count} -ne ${expected_calls} ]; then
                 assertion_failed "Command '${command}' was expected to be called $(_format_count ${expected_calls} "time")\nCalled : $(_format_count ${call_count} "time")"
             fi
+        done
+
+        for invocation in $(find ${mock} -maxdepth 1 -name "invocation_*_error" 2>/dev/null || true); do
+            assertion_failed "$(cat $invocation)"
         done
     done
 }

--- a/test-fixtures/mocking-args-strict/src/code.sh
+++ b/test-fixtures/mocking-args-strict/src/code.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# N.B. no `set -e` here!
+
+some-command one un
+some-command three trois || true # Failure here doesnt matter to the actual code.
+some-command two deux
+
+exit 0

--- a/test-fixtures/mocking-args-strict/test/test_verify_arguments_order.sh
+++ b/test-fixtures/mocking-args-strict/test/test_verify_arguments_order.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+test_fails_when_verifying_arguments_even_if_exit_code_is_ignored() {
+    mock some-command --with-args "one un" --once
+    mock some-command --with-args "two deux" --once
+    mock some-command --with-args "three trois" --once
+
+    ./code.sh
+}

--- a/test/test_assert.sh
+++ b/test/test_assert.sh
@@ -31,7 +31,7 @@ test_assert_equals_with_strings_passing() {
 test_assert_equals_with_strings_failing() {
     assert "no" equals "yes" > assertion_output
     result=${?}
-    rm .assertion_error # The test runner would think the test failed
+    _hide_assertion_failure_from_test_runner
 
     assertion_error=$(cat assertion_output)
 
@@ -48,4 +48,32 @@ test_assert_multiworks_string_works() {
     (assert "yes but no" equals "yes but no")
 
     assert ${?} succeeded
+}
+
+test_assert_contains() {
+    assert "hello world" contains "^hello world$"
+    assert "hello world" contains "^hello"
+    assert "hello world" contains "world$"
+    assert "hello world" contains "w"
+}
+
+test_assert_contains_fails_with_proper_error_message() {
+    assert "abc" contains "z$" > assertion_output
+    result=${?}
+    _hide_assertion_failure_from_test_runner
+
+    assertion_error=$(cat assertion_output)
+
+    expected_error=$(cat <<-EXP
+Expected:         <abc>
+To match pattern: <z$>
+EXP
+)
+    assert ${result} failed
+    assert "${assertion_error}" equals "${expected_error}"
+}
+
+_hide_assertion_failure_from_test_runner() {
+    # The test runner would think the test failed
+    rm .assertion_error
 }

--- a/test/test_mocking_args_matching.sh
+++ b/test/test_mocking_args_matching.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-test_fails_if_given_arguments_isnt_right() {
-    mock some-command --with-args "one two three"
+test_fails_when_verifying_arguments_even_when_exit_code_is_ignored() {
+    cp -aR ${TEST_ROOT_DIR}/../test-fixtures/mocking-args-strict/* .
 
-    some-command three two one > assertion_output
+    unset RUN_SINGLE_TEST
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh verify_arguments_order)
     assert ${?} failed
 
     expected_error=$(cat <<-EXP
 Unexpected invocation for command 'some-command':
-Got :      <"three two one">
-Expected : <"one two three">
+Got :      <"three trois">
+Expected : <"two deux">
+Unexpected invocation for command 'some-command':
+Got :      <"two deux">
+Expected : <"three trois">
 EXP
 )
-    assert "$(cat assertion_output)" equals "${expected_error}"
+    assert "${actual}" contains "${expected_error}"
 }
 
-test_fails_if_2_with_args_argments_are_given() {
+test_fails_if_2_with_args_arguments_are_given() {
     mock some-command --with-args "a" --with-args "b" > error
     assert ${?} failed
 


### PR DESCRIPTION
Currently, mock arguments were verified inside the mock itself. Using a mock in a script not running in errexit mode (set -e) or hiding the failure meant silent failures and successful tests.

Signal the invocation failure through the mocks workspace and verify success during the verify_mocks phase.

Additionally, the build script has been adjusted to avoid having to add new lines at the end of every source file.

Finally, a "contains" assert has been added.