### PR TITLE
Allow running "inplace"

### DIFF
--- a/src/cli.sh
+++ b/src/cli.sh
@@ -5,6 +5,7 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
     test_sources_root="test"
     test_suites_filter="test_*"
     test_filter="^test_"
+    run_inplace="false"
 
     while [[ $# -gt 0 ]]; do
         key="$1"
@@ -15,6 +16,13 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
             ;;
             --tests)
             test_sources_root="$2"; shift
+            ;;
+            --inplace)
+            run_inplace="true";
+            ;;
+            --*)
+            echo "Unsupported argument ${key}" > /dev/stderr
+            exit 1
             ;;
             *)
             if [[ ${key} == *"."* ]]; then
@@ -40,7 +48,7 @@ if [ -z "${RUN_SINGLE_TEST:-""}" ]; then
     failure_count=0
 
     for f in $(find ${test_sources_root} -name "${test_suites_filter}" | sort); do
-        TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${test_filter} ${registry} || fail "${f} failed."
+        RUN_INPLACE=${run_inplace} TEST_ROOT_DIR=${test_sources_root} RUN_SINGLE_TEST=1 $0 ${sources_root} ${f} ${test_filter} ${registry} || fail "${f} failed."
 
         new_tests=$(cat ${registry}/test_count)
         test_count=$((${test_count} + ${new_tests}))

--- a/test-fixtures/inplace-test/src/code.sh
+++ b/test-fixtures/inplace-test/src/code.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+# Use the root Makefile to ensure we have not been copied elsewhere.
+test -f $(pwd)/../../../Makefile

--- a/test-fixtures/inplace-test/test/test_code.sh
+++ b/test-fixtures/inplace-test/test/test_code.sh
@@ -1,0 +1,5 @@
+
+test_path() {
+    ./code.sh
+    assert $? succeeded
+}

--- a/test/test_runner_args.sh
+++ b/test/test_runner_args.sh
@@ -124,3 +124,10 @@ EXP
 )
     assert "${actual}" equals "${expected}"
 }
+
+test_refuses_invalid_arguments() {
+    actual=$(${TEST_ROOT_DIR}/../target/sbtest.sh --invalid 2>&1 1>/dev/null)
+    assert ${?} failed
+
+    assert "$actual" equals "Unsupported argument --invalid"
+}

--- a/test/test_runner_inplace.sh
+++ b/test/test_runner_inplace.sh
@@ -1,0 +1,7 @@
+
+test_inplace_mode_runs_inplace() {
+    unset RUN_SINGLE_TEST
+
+    ${TEST_ROOT_DIR}/../target/sbtest.sh --inplace --src ${TEST_ROOT_DIR}/../test-fixtures/inplace-test/src --tests ${TEST_ROOT_DIR}/../test-fixtures/inplace-test/test
+    assert ${?} succeeded
+}


### PR DESCRIPTION
Currently, sources and tests files are copied to the workspace and
executed from there. This works well to prevent accidental files and
directories from being created around the test subject.

However, this means it is impossible to use resources around the test,
without resorting to ${TEST_ROOT_DIR} and, most importantly, tools such
as bashcov are unable to report usage of source files because they have
been run from an external copy.