### PR TITLE
Add support for quotes and double quotes in --with-args

### DIFF
--- a/src/mocking.sh
+++ b/src/mocking.sh
@@ -34,16 +34,16 @@ EOF
 }
 
 validate-args() {
-    expected="$@"
+    file=$(mktemp validate-args.XXXXXXXXX)
+    echo "$@" > ${file}
+
     cat <<EOF
 args="\$@"
-
-if [ "\${args}" != "${expected}" ]; then
-
+if [ "\${args}" != "\$(cat ${file})" ]; then
     cat <<OUT
 Unexpected invocation for command 'some-command':
 Got :      <"\${args}">
-Expected : <"${expected}">
+Expected : <"\$(cat ${file})">
 OUT
     exit 1
 fi

--- a/test/test_mocking_args_matching.sh
+++ b/test/test_mocking_args_matching.sh
@@ -21,3 +21,24 @@ test_fails_if_2_with_args_argments_are_given() {
 
     assert "$(cat error)" equals "Cannot expect more than 1 set of argument for an invocation, please use 'mock' multiple times"
 }
+
+test_supports_escaped_quotes_in_args() {
+    mock some-command --with-args "one 'two' three"
+
+    some-command one \'two\' three
+    assert ${?} succeeded
+}
+
+test_supports_escaped_double_quotes_in_args() {
+    mock some-command --with-args "one \"two\" three"
+
+    some-command one \"two\" three
+    assert ${?} succeeded
+}
+
+test_supports_escaped_double_quotes_in_single_quotes_in_args() {
+    mock some-command --with-args 'one "two" three'
+
+    some-command 'one "two" three'
+    assert ${?} succeeded
+}


### PR DESCRIPTION
Comparing a variable was parsing the quotes/double-quotes even when
trying to escape them wiht string manipulation. Solution is a file
content because it leaves the content as is.